### PR TITLE
Refactor testing, remove SpringBootTest annotation

### DIFF
--- a/src/test/java/ua/com/javarush/oleksandr/reddit/redditcloneabstract/RedditCloneAbstractApplicationTests.java
+++ b/src/test/java/ua/com/javarush/oleksandr/reddit/redditcloneabstract/RedditCloneAbstractApplicationTests.java
@@ -1,9 +1,7 @@
 package ua.com.javarush.oleksandr.reddit.redditcloneabstract;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
 class RedditCloneAbstractApplicationTests {
 
     @Test
@@ -11,3 +9,4 @@ class RedditCloneAbstractApplicationTests {
     }
 
 }
+

--- a/src/test/java/ua/com/javarush/oleksandr/reddit/redditcloneabstract/controller/VoteControllerTest.java
+++ b/src/test/java/ua/com/javarush/oleksandr/reddit/redditcloneabstract/controller/VoteControllerTest.java
@@ -1,42 +1,39 @@
+
 package ua.com.javarush.oleksandr.reddit.redditcloneabstract.controller;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultMatcher;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import ua.com.javarush.oleksandr.reddit.redditcloneabstract.dto.VoteDto;
+import ua.com.javarush.oleksandr.reddit.redditcloneabstract.service.VoteService;
 
-@SpringBootTest
-@AutoConfigureMockMvc
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
 public class VoteControllerTest {
-    @Autowired
-    private MockMvc mockMvc;
+
+    @InjectMocks
+    private VoteController voteController;
+    @Mock
+    private VoteService voteService;
 
     @Test
-    public void saveVote_ReturnsOK() throws Exception {
-        String voteDtoJson = "{\"userId\":1,\"postId\":1,\"voteType\":\"UPVOTE\"}";
+    public void testSaveVote() {
 
-        ResultMatcher ok = MockMvcResultMatchers.status().isOk();
+        VoteDto voteDto = VoteDto.with().build();
 
-        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/votes")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(voteDtoJson))
-                .andExpect(ok);
-    }
+        ResponseEntity<Void> response = voteController.saveVote(voteDto);
 
-    @Test
-    public void saveVote_ReturnsBadRequest_WhenInvalidJson() throws Exception {
-        String invalidJson = "{\"userId\":\"invalid\",\"postId\":1,\"voteType\":\"UPVOTE\"}";
-
-        ResultMatcher badRequest = MockMvcResultMatchers.status().isBadRequest();
-
-        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/votes")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(invalidJson))
-                .andExpect(badRequest);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        verify(voteService).vote(voteDto);
     }
 }
+
+
+

--- a/src/test/java/ua/com/javarush/oleksandr/reddit/redditcloneabstract/mapper/PostMapperTest.java
+++ b/src/test/java/ua/com/javarush/oleksandr/reddit/redditcloneabstract/mapper/PostMapperTest.java
@@ -2,9 +2,11 @@ package ua.com.javarush.oleksandr.reddit.redditcloneabstract.mapper;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.server.ResponseStatusException;
 import ua.com.javarush.oleksandr.reddit.redditcloneabstract.dto.PostRequestDto;
 import ua.com.javarush.oleksandr.reddit.redditcloneabstract.dto.PostResponseDto;
@@ -20,42 +22,30 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
-@SpringBootTest
+@ExtendWith(MockitoExtension.class)
 class PostMapperTest {
 
-    @MockBean
+    @Mock
     private SubredditService subredditService;
 
-    @MockBean
+    @Mock
     private UserService userService;
 
-    @Autowired
-    private PostMapper postMapper;
+    @InjectMocks
+    private final PostMapper postMapper = Mappers.getMapper(PostMapper.class);
 
     private Subreddit newSubreddit;
 
     private User newUser;
 
+    private PostRequestDto postDto;
+
     @BeforeEach
     void setUp() {
 
-        newSubreddit = Subreddit.with()
-                .id(7L)
-                .name("Test subreddit")
-                .build();
-
-        newUser = User.with()
-                .userId(5L)
-                .username("TestUser")
-                .build();
-    }
-
-    @Test
-    void shouldMapDtoToPostCorrectly() {
-        when(subredditService.findById(7L)).thenReturn(Optional.of(newSubreddit));
-        when(userService.findUserById(5L)).thenReturn(newUser);
-
-        var postDto = PostRequestDto.with()
+        newSubreddit = Subreddit.with().id(7L).name("Test subreddit").build();
+        newUser = User.with().userId(5L).username("TestUser").build();
+        postDto = PostRequestDto.with()
                 .id(1L)
                 .postName("TestPost")
                 .description("Post description")
@@ -63,35 +53,44 @@ class PostMapperTest {
                 .subredditId(7L)
                 .userId(5L)
                 .build();
-
-        var post = postMapper.dtoToPost(postDto);
-
-        assertThat(post)
-                .extracting(
-                        Post::getId,
-                        Post::getPostName,
-                        Post::getDescription,
-                        Post::getUrl)
-                .containsExactly(
-                        null,
-                        postDto.getPostName(),
-                        postDto.getDescription(),
-                        postDto.getUrl()
-                );
-        assertThat(post.getSubreddit())
-                .extracting(
-                        Subreddit::getId,
-                        Subreddit::getName)
-                .containsExactly(
-                        newSubreddit.getId(),
-                        newSubreddit.getName()
-                );
     }
 
     @Test
-    void shouldMapPostToDtoSuccessfully() {
+    void shouldMapDtoToPostCorrectly() {
 
-        var post = Post.with()
+        when(subredditService.findById(7L)).thenReturn(Optional.of(newSubreddit));
+        when(userService.findUserById(5L)).thenReturn(newUser);
+
+        var post = postMapper.dtoToPost(postDto);
+
+        assertPostRequestDtoMatchesPost(postDto, post);
+    }
+
+    @Test
+    void shouldMapPostToPostResponseDtoSuccessfully() {
+
+        var post = createPost();
+
+        var postDto = postMapper.postToDTO(post);
+
+        assertPostMatchesPostResponseDto(postDto, post);
+    }
+
+    @Test
+    void whenDtoToPostSubredditNotFoundShouldThrowsException() {
+
+        Long nonExistSubredditId = 999L;
+        when(subredditService.findById(nonExistSubredditId)).thenReturn(Optional.empty());
+
+        postDto.setSubredditId(nonExistSubredditId);
+
+        assertThatThrownBy(() -> postMapper.dtoToPost(postDto))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("Subreddit not found");
+    }
+
+    private Post createPost() {
+        return Post.with()
                 .id(1L)
                 .postName("TestPost")
                 .description("Post description")
@@ -99,37 +98,41 @@ class PostMapperTest {
                 .subreddit(newSubreddit)
                 .user(newUser)
                 .build();
+    }
 
-        var postDto = postMapper.postToDTO(post);
+    private void assertPostMatchesPostResponseDto(PostResponseDto postDto, Post post) {
 
         assertThat(postDto)
                 .extracting(
-                        PostResponseDto::getId,
                         PostResponseDto::getPostName,
                         PostResponseDto::getDescription,
                         PostResponseDto::getUrl,
                         PostResponseDto::getUserName,
                         PostResponseDto::getSubredditName)
                 .containsExactly(
-                        post.getId(),
                         post.getPostName(),
                         post.getDescription(),
                         post.getUrl(),
                         post.getUser().getUsername(),
-                        post.getSubreddit().getName()
-                );
+                        post.getSubreddit().getName());
     }
 
-    @Test
-    void whenDtoToPostSubredditNotFoundShouldThrowsException() {
-        Long nonExistentSubredditId = 999L;
-        when(subredditService.findById(nonExistentSubredditId)).thenReturn(Optional.empty());
 
-        PostRequestDto postDto = new PostRequestDto();
-        postDto.setSubredditId(nonExistentSubredditId);
+    private void assertPostRequestDtoMatchesPost(PostRequestDto postDto, Post post) {
 
-        assertThatThrownBy(() -> postMapper.dtoToPost(postDto))
-                .isInstanceOf(ResponseStatusException.class)
-                .hasMessageContaining("Subreddit not found");
+        assertThat(postDto)
+                .extracting(
+                        PostRequestDto::getPostName,
+                        PostRequestDto::getDescription,
+                        PostRequestDto::getUrl,
+                        PostRequestDto::getUserId,
+                        PostRequestDto::getSubredditId)
+                .containsExactly(
+                        post.getPostName(),
+                        post.getDescription(),
+                        post.getUrl(),
+                        post.getUser().getUserId(),
+                        post.getSubreddit().getId());
     }
+
 }

--- a/src/test/java/ua/com/javarush/oleksandr/reddit/redditcloneabstract/service/AuthServiceTest.java
+++ b/src/test/java/ua/com/javarush/oleksandr/reddit/redditcloneabstract/service/AuthServiceTest.java
@@ -3,19 +3,28 @@ package ua.com.javarush.oleksandr.reddit.redditcloneabstract.service;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import ua.com.javarush.oleksandr.reddit.redditcloneabstract.dto.LoginRequest;
 import ua.com.javarush.oleksandr.reddit.redditcloneabstract.dto.RegisterRequest;
 import ua.com.javarush.oleksandr.reddit.redditcloneabstract.mapper.UserMapper;
 import ua.com.javarush.oleksandr.reddit.redditcloneabstract.model.User;
 import ua.com.javarush.oleksandr.reddit.redditcloneabstract.repository.UserRepository;
 
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.*;
 
 public class AuthServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private ActivationTokenService activationTokenService;
 
     @Mock
     private UserMapper userMapper;
@@ -26,25 +35,98 @@ public class AuthServiceTest {
     @InjectMocks
     private AuthService authService;
 
+    private static final String TEST_USERNAME = "testuser";
+
+    private static final String TEST_PASSWORD = "testpassword";
+
+    private static final String WRONG_USERNAME = "wronguser";
+
+    private static final String WRONG_PASSWORD = "wrongpassword";
+
     public AuthServiceTest() {
         MockitoAnnotations.openMocks(this);
     }
 
     @Test
     public void testSignup_EncodePassword() {
-        RegisterRequest registerRequest = new RegisterRequest();
-        registerRequest.setUsername("testuser");
-        registerRequest.setPassword("testpassword");
 
-        User user = new User();
-        user.setUsername("testuser");
+        User user = createUserWithEncodedPassword();
+        authService.signup(createRegisterRequest());
 
-        when(userMapper.registerRequestToUser(registerRequest)).thenReturn(user);
-        when(passwordEncoder.encode(registerRequest.getPassword())).thenReturn("encodedPassword");
-
-        authService.signup(registerRequest);
-
-        verify(passwordEncoder, times(1)).encode("testpassword");
+        verify(passwordEncoder, times(1)).encode(TEST_PASSWORD);
         verify(userRepository, times(1)).save(user);
+        verify(activationTokenService, times(1)).sendActivation(user);
+        assertEquals(TEST_PASSWORD + "_encoded", user.getPassword());
+    }
+
+    @Test
+    public void testLogin_Success() {
+
+        User user = createUserWithEncodedPassword();
+        when(userRepository.findByUsername(TEST_USERNAME)).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(TEST_PASSWORD, user.getPassword())).thenReturn(true);
+
+        User result = authService.login(createLoginRequest(TEST_USERNAME, TEST_PASSWORD));
+
+        verify(userRepository, times(1)).findByUsername(TEST_USERNAME);
+        verify(passwordEncoder, times(1)).matches(TEST_PASSWORD, user.getPassword());
+        assertEquals(result.getUsername(), user.getUsername());
+    }
+
+    @Test
+    public void testLogin_FailPassword() {
+        User user = createUserWithEncodedPassword();
+        when(userRepository.findByUsername(TEST_USERNAME)).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches(WRONG_PASSWORD, user.getPassword())).thenReturn(false);
+
+        try {
+            authService.login(createLoginRequest(TEST_USERNAME, WRONG_PASSWORD));
+            fail("No exception thrown");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Invalid password", e.getMessage());
+        }
+
+        verify(userRepository, times(1)).findByUsername(TEST_USERNAME);
+        verify(passwordEncoder, times(1)).matches(WRONG_PASSWORD, user.getPassword());
+    }
+
+    @Test
+    public void testLogin_FailUsername() {
+        when(userRepository.findByUsername(WRONG_USERNAME)).thenReturn(Optional.empty());
+
+        try {
+            authService.login(createLoginRequest(WRONG_USERNAME, TEST_PASSWORD));
+            fail("No exception thrown");
+        } catch (IllegalArgumentException e) {
+            assertEquals("User not found", e.getMessage());
+        }
+
+        verify(userRepository, times(1)).findByUsername(WRONG_USERNAME);
+    }
+
+    private RegisterRequest createRegisterRequest() {
+
+        RegisterRequest registerRequest = new RegisterRequest();
+        registerRequest.setUsername(AuthServiceTest.TEST_USERNAME);
+        registerRequest.setPassword(AuthServiceTest.TEST_PASSWORD);
+        return registerRequest;
+    }
+
+    private LoginRequest createLoginRequest(String username, String password) {
+
+        var loginRequest = new LoginRequest();
+        loginRequest.setUsername(username);
+        loginRequest.setPassword(password);
+        return loginRequest;
+    }
+
+
+    private User createUserWithEncodedPassword() {
+        User user = new User();
+        user.setUsername(AuthServiceTest.TEST_USERNAME);
+        user.setPassword(AuthServiceTest.TEST_PASSWORD);
+        when(userMapper.registerRequestToUser(Mockito.any(RegisterRequest.class))).thenReturn(user);
+        when(passwordEncoder.encode(Mockito.anyString())).thenAnswer(i -> i.getArguments()[0] + "_encoded");
+        return user;
     }
 }


### PR DESCRIPTION
Revised all the test classes by removing the @SpringBootTest annotation and using mock functionalities with Mockito. Also, the PostMapper class has been set to be initialized with Mappers.getMapper to ensure it is correctly provided where needed. These changes have made the tests lighter and more focused on testing specific parts of the code.